### PR TITLE
declared type in expand_url

### DIFF
--- a/src/Longurl.jl
+++ b/src/Longurl.jl
@@ -22,7 +22,7 @@ Takes a list of short urls and exands them into their long form
 - `Urls`: Struct containing properties expanded_url and status_code
 ...
 """
-function expand_urls(urls_to_expand, seconds=2)
+function expand_urls(urls_to_expand::A, seconds::N=2) where {A<:Union{String,Vector{String}}, N <: Number} 
 
     original_stdout = stdout
     original_error = stderr


### PR DESCRIPTION
Added an explicit type declaration for expand_url

I believe it can take both a single string or a vector of strings as input.